### PR TITLE
Add support to folders with spaces

### DIFF
--- a/generate-codecov-json.js
+++ b/generate-codecov-json.js
@@ -39,7 +39,8 @@ function getFileList (archivePath) {
 }
 
 function getCoverageInfo (filePath) {
-  return execSync(`xcrun xccov view --archive ${archivePath} --file ${filePath}`, { stdio: [process.stdout] }).toString()
+  const safeFilePath = filePath.toString().replace(' ', '\\ ');
+  return execSync(`xcrun xccov view --archive ${archivePath} --file ${safeFilePath}`, { stdio: [process.stdout] }).toString()
 }
 
 function convertCoverage (coverageInfo) {


### PR DESCRIPTION
The function `getCoverageInfo` from the `generate-codecov-json.js` doesn't support folders with names, this PR escapes those values and allows the function to properly find the file from the coverage.